### PR TITLE
Create GitBook-style documentation theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,245 @@
 <!DOCTYPE html>
-<html>
-<body>
-<h1>Hello World</h1>
-<p>I'm hosted with GitHub Pages.</p>
-</body>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vincent Schaik — Documentation</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div class="layout">
+      <header class="topbar">
+        <button class="menu-button" aria-label="Toggle navigation" aria-expanded="false">
+          <span class="menu-button__bar"></span>
+          <span class="menu-button__bar"></span>
+          <span class="menu-button__bar"></span>
+        </button>
+        <div class="topbar__brand">
+          <span class="topbar__title">Project Documentation</span>
+          <span class="topbar__subtitle">Organise your knowledge in one place</span>
+        </div>
+        <label class="search" for="search">
+          <span class="sr-only">Search the documentation</span>
+          <svg
+            class="search__icon"
+            viewBox="0 0 24 24"
+            width="20"
+            height="20"
+            aria-hidden="true"
+          >
+            <path
+              d="M15.5 14h-.79l-.28-.27a6.5 6.5 0 10-.71.71l.27.28v.79l4.25 4.25a1 1 0 001.41-1.41L15.5 14zm-6 0a4.5 4.5 0 110-9 4.5 4.5 0 010 9z"
+              fill="currentColor"
+            />
+          </svg>
+          <input id="search" type="search" placeholder="Search docs (coming soon)" />
+        </label>
+      </header>
+
+      <aside class="sidebar" aria-label="Main navigation">
+        <div class="sidebar__inner">
+          <div class="sidebar__section">
+            <h2 class="sidebar__heading">Getting started</h2>
+            <ul class="sidebar__links">
+              <li><a href="#introduction">Introduction</a></li>
+              <li><a href="#quick-start">Quick start</a></li>
+              <li><a href="#project-structure">Project structure</a></li>
+            </ul>
+          </div>
+          <div class="sidebar__section">
+            <h2 class="sidebar__heading">Guides</h2>
+            <ul class="sidebar__links">
+              <li><a href="#writing-docs">Writing documentation</a></li>
+              <li><a href="#customisation">Customisation</a></li>
+              <li><a href="#deployment">Deployment</a></li>
+            </ul>
+          </div>
+          <div class="sidebar__section">
+            <h2 class="sidebar__heading">References</h2>
+            <ul class="sidebar__links">
+              <li><a href="#components">Components</a></li>
+              <li><a href="#faq">FAQ</a></li>
+              <li><a href="#resources">Further resources</a></li>
+            </ul>
+          </div>
+        </div>
+      </aside>
+
+      <main class="content" id="content">
+        <article class="doc">
+          <section id="introduction" class="doc__section">
+            <h1>Welcome to your documentation hub</h1>
+            <p>
+              Use this GitBook-inspired theme to centralise the knowledge around your project or
+              product. The layout is optimised for readability with a persistent navigation sidebar,
+              subtle typography, and plenty of room for long-form guides.
+            </p>
+            <p>
+              Replace the sample content with your own documentation pages. Each section is linked in
+              the sidebar, making it easy for readers to jump directly to what they need.
+            </p>
+            <div class="callout callout--info">
+              <h3 class="callout__title">Tip</h3>
+              <p class="callout__content">
+                You can add more pages by duplicating this template and updating the sidebar links to
+                match your new sections.
+              </p>
+            </div>
+          </section>
+
+          <section id="quick-start" class="doc__section">
+            <h2>Quick start</h2>
+            <ol>
+              <li><strong>Plan</strong> your documentation structure and define your main sections.</li>
+              <li><strong>Create</strong> a new section in the sidebar for each major topic.</li>
+              <li><strong>Write</strong> focused pages using clear headings and consistent tone.</li>
+              <li><strong>Publish</strong> changes by committing to your GitHub Pages repository.</li>
+            </ol>
+            <p>
+              The <code>styles.css</code> file controls the appearance of the theme. Tweak the color
+              palette or typography to align with your brand.
+            </p>
+          </section>
+
+          <section id="project-structure" class="doc__section">
+            <h2>Project structure</h2>
+            <p>
+              This starter comes with just three files: <code>index.html</code>, <code>styles.css</code>,
+              and <code>script.js</code>. They are small and easy to customise.
+            </p>
+            <table class="table">
+              <thead>
+                <tr>
+                  <th>File</th>
+                  <th>Description</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td><code>index.html</code></td>
+                  <td>Main layout and content for the documentation homepage.</td>
+                </tr>
+                <tr>
+                  <td><code>styles.css</code></td>
+                  <td>Theme styling, including colors, typography, and responsive layout.</td>
+                </tr>
+                <tr>
+                  <td><code>script.js</code></td>
+                  <td>Enhancements such as the mobile navigation toggle.</td>
+                </tr>
+              </tbody>
+            </table>
+          </section>
+
+          <section id="writing-docs" class="doc__section">
+            <h2>Writing documentation</h2>
+            <p>
+              Keep your guides concise and approachable. Use short paragraphs, descriptive headings,
+              and callouts for important information. This template supports blockquotes, lists, code
+              samples, and tables, so feel free to mix and match content blocks as needed.
+            </p>
+            <blockquote>
+              Well-crafted docs turn knowledge into a renewable resource for your team.
+            </blockquote>
+            <pre class="code-block"><code>// Example: Highlighting a shell command
+npm install
+npm run docs
+</code></pre>
+          </section>
+
+          <section id="customisation" class="doc__section">
+            <h2>Customisation</h2>
+            <p>
+              Adjust the colour palette by editing the CSS variables at the top of the stylesheet. You
+              can also integrate a static site generator or markdown processor if your documentation
+              grows beyond a single page.
+            </p>
+            <ul>
+              <li>Update brand colors and fonts</li>
+              <li>Swap the logo text for an SVG asset</li>
+              <li>Connect the search input to your preferred search provider</li>
+            </ul>
+          </section>
+
+          <section id="deployment" class="doc__section">
+            <h2>Deployment</h2>
+            <p>
+              Host your documentation with GitHub Pages, Netlify, Vercel, or any static hosting
+              provider. Whenever you push changes to the <code>main</code> branch, the latest version of
+              your docs will go live.
+            </p>
+          </section>
+
+          <section id="components" class="doc__section">
+            <h2>Components</h2>
+            <p>
+              The following components are included to help you structure content with minimal effort:
+            </p>
+            <div class="cards">
+              <article class="card">
+                <h3>Callouts</h3>
+                <p>Draw attention to warnings, tips, or important notes.</p>
+              </article>
+              <article class="card">
+                <h3>Tables</h3>
+                <p>Summarise configuration options, command references, or release notes.</p>
+              </article>
+              <article class="card">
+                <h3>Code blocks</h3>
+                <p>Share runnable examples or configuration snippets with syntax-friendly styling.</p>
+              </article>
+            </div>
+          </section>
+
+          <section id="faq" class="doc__section">
+            <h2>Frequently asked questions</h2>
+            <details class="accordion" open>
+              <summary>Can I add more pages?</summary>
+              <p>
+                Absolutely. Duplicate this file and update the navigation. For larger docs, consider a
+                build step to generate pages from Markdown.
+              </p>
+            </details>
+            <details class="accordion">
+              <summary>Does this support dark mode?</summary>
+              <p>
+                A dark theme is easy to add. Extend the CSS with a <code>[data-theme="dark"]</code>
+                selector and toggle it via JavaScript.
+              </p>
+            </details>
+            <details class="accordion">
+              <summary>Can I embed rich media?</summary>
+              <p>
+                Yes, you can embed images, videos, or interactive demos just like any HTML page.
+              </p>
+            </details>
+          </section>
+
+          <section id="resources" class="doc__section">
+            <h2>Further resources</h2>
+            <p>Explore these links to learn more about writing great documentation:</p>
+            <ul>
+              <li><a href="https://www.writethedocs.org/">Write the Docs community</a></li>
+              <li><a href="https://diataxis.fr/">Diátaxis documentation framework</a></li>
+              <li><a href="https://github.com/GitbookIO/gitbook">GitBook on GitHub</a></li>
+            </ul>
+          </section>
+        </article>
+        <footer class="footer">
+          <p>
+            Built with ❤️ for clear communication. Update this footer with your team's contact
+            details or contribution guidelines.
+          </p>
+        </footer>
+      </main>
+    </div>
+
+    <script src="script.js"></script>
+  </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,16 @@
+const menuButton = document.querySelector('.menu-button');
+const sidebar = document.querySelector('.sidebar');
+
+if (menuButton && sidebar) {
+  menuButton.addEventListener('click', () => {
+    const isOpen = sidebar.classList.toggle('is-open');
+    menuButton.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+  });
+
+  sidebar.addEventListener('click', (event) => {
+    if (event.target.matches('a')) {
+      sidebar.classList.remove('is-open');
+      menuButton.setAttribute('aria-expanded', 'false');
+    }
+  });
+}

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,429 @@
+:root {
+  --bg-color: #f9fafb;
+  --surface-color: #ffffff;
+  --border-color: #e5e7eb;
+  --sidebar-bg: #111827;
+  --sidebar-text: #f9fafb;
+  --sidebar-muted: #9ca3af;
+  --primary-color: #6366f1;
+  --primary-text: #1f2937;
+  --muted-text: #4b5563;
+  --code-bg: #111827;
+  --code-text: #f9fafb;
+  --callout-info-bg: rgba(99, 102, 241, 0.1);
+  --callout-info-border: rgba(99, 102, 241, 0.4);
+  --shadow-color: rgba(15, 23, 42, 0.06);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: var(--bg-color);
+  color: var(--primary-text);
+  line-height: 1.6;
+  text-rendering: optimizeLegibility;
+}
+
+.layout {
+  min-height: 100vh;
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  grid-template-rows: auto 1fr;
+  grid-template-areas:
+    "sidebar topbar"
+    "sidebar content";
+}
+
+.topbar {
+  grid-area: topbar;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 1rem 2rem;
+  background: var(--surface-color);
+  border-bottom: 1px solid var(--border-color);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.menu-button {
+  display: none;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0.4rem;
+  border-radius: 0.5rem;
+  transition: background 0.2s ease;
+}
+
+.menu-button:focus-visible,
+.menu-button:hover {
+  background: rgba(99, 102, 241, 0.12);
+}
+
+.menu-button__bar {
+  display: block;
+  width: 20px;
+  height: 2px;
+  margin: 4px 0;
+  background: var(--primary-text);
+  border-radius: 2px;
+  transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+.topbar__brand {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-width: 0;
+}
+
+.topbar__title {
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.topbar__subtitle {
+  font-size: 0.85rem;
+  color: var(--muted-text);
+}
+
+.search {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: var(--bg-color);
+  border: 1px solid var(--border-color);
+  border-radius: 9999px;
+  padding: 0.5rem 0.75rem;
+  min-width: 220px;
+}
+
+.search__icon {
+  color: var(--muted-text);
+}
+
+.search input {
+  border: none;
+  background: transparent;
+  font-size: 0.9rem;
+  width: 100%;
+  color: var(--primary-text);
+}
+
+.search input:focus {
+  outline: none;
+}
+
+.sidebar {
+  grid-area: sidebar;
+  background: var(--sidebar-bg);
+  color: var(--sidebar-text);
+  padding: 1.5rem 1.25rem;
+  position: sticky;
+  top: 0;
+  bottom: 0;
+  overflow-y: auto;
+}
+
+.sidebar__inner {
+  position: sticky;
+  top: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.sidebar__heading {
+  text-transform: uppercase;
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  color: var(--sidebar-muted);
+  margin-bottom: 0.75rem;
+}
+
+.sidebar__links {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.sidebar__links a {
+  color: inherit;
+  text-decoration: none;
+  font-weight: 500;
+  font-size: 0.95rem;
+  padding: 0.35rem 0.4rem;
+  border-radius: 0.4rem;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.sidebar__links a:hover,
+.sidebar__links a:focus {
+  background: rgba(99, 102, 241, 0.18);
+  color: #fff;
+  outline: none;
+}
+
+.content {
+  grid-area: content;
+  background: var(--bg-color);
+  padding: 2rem 3.5rem 4rem;
+}
+
+.doc {
+  max-width: 860px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 3rem;
+}
+
+.doc__section h1,
+.doc__section h2,
+.doc__section h3 {
+  font-weight: 600;
+  margin-top: 0;
+  color: var(--primary-text);
+}
+
+.doc__section h1 {
+  font-size: 2.2rem;
+}
+
+.doc__section h2 {
+  font-size: 1.6rem;
+  margin-bottom: 1rem;
+}
+
+.doc__section p {
+  margin: 0.5rem 0 1rem;
+  color: var(--muted-text);
+}
+
+.doc__section ul,
+.doc__section ol {
+  padding-left: 1.2rem;
+  color: var(--muted-text);
+}
+
+.doc__section li {
+  margin-bottom: 0.5rem;
+}
+
+.doc__section code {
+  font-family: "JetBrains Mono", "Fira Code", "Source Code Pro", monospace;
+  background: rgba(15, 23, 42, 0.08);
+  padding: 0.15rem 0.35rem;
+  border-radius: 0.35rem;
+  font-size: 0.9rem;
+}
+
+.code-block {
+  background: var(--code-bg);
+  color: var(--code-text);
+  border-radius: 0.8rem;
+  padding: 1.25rem;
+  font-size: 0.95rem;
+  overflow-x: auto;
+  box-shadow: 0 16px 30px -25px rgba(15, 23, 42, 0.7);
+}
+
+.callout {
+  border-left: 4px solid var(--callout-info-border);
+  background: var(--callout-info-bg);
+  padding: 1rem 1.25rem;
+  border-radius: 0.6rem;
+  color: var(--muted-text);
+}
+
+.callout__title {
+  margin: 0 0 0.35rem;
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--primary-text);
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1.5rem;
+  box-shadow: 0 12px 30px -20px var(--shadow-color);
+}
+
+.table th,
+.table td {
+  padding: 0.75rem 1rem;
+  text-align: left;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.table th {
+  background: rgba(99, 102, 241, 0.08);
+  font-weight: 600;
+  color: var(--primary-text);
+}
+
+.table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+blockquote {
+  margin: 1.5rem 0;
+  padding: 1rem 1.2rem;
+  border-left: 4px solid var(--primary-color);
+  background: rgba(99, 102, 241, 0.1);
+  color: var(--muted-text);
+  border-radius: 0.5rem;
+}
+
+.cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1.5rem;
+}
+
+.card {
+  background: var(--surface-color);
+  border: 1px solid var(--border-color);
+  border-radius: 0.8rem;
+  padding: 1.5rem;
+  box-shadow: 0 18px 40px -30px var(--shadow-color);
+}
+
+.card h3 {
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+}
+
+.card p {
+  margin: 0;
+}
+
+.accordion {
+  background: var(--surface-color);
+  border-radius: 0.6rem;
+  padding: 1rem 1.25rem;
+  border: 1px solid var(--border-color);
+  box-shadow: 0 12px 30px -25px var(--shadow-color);
+}
+
+.accordion + .accordion {
+  margin-top: 0.75rem;
+}
+
+.accordion summary {
+  cursor: pointer;
+  font-weight: 600;
+  color: var(--primary-text);
+}
+
+.accordion p {
+  margin-top: 0.75rem;
+}
+
+.footer {
+  margin-top: 4rem;
+  padding: 2rem 0 0;
+  border-top: 1px solid var(--border-color);
+  color: var(--muted-text);
+  text-align: center;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+@media (max-width: 1080px) {
+  .layout {
+    grid-template-columns: 1fr;
+    grid-template-areas:
+      "topbar"
+      "content";
+  }
+
+  .sidebar {
+    position: fixed;
+    inset: 0 40% 0 0;
+    transform: translateX(-100%);
+    transition: transform 0.3s ease;
+    z-index: 20;
+    max-width: 320px;
+    box-shadow: 16px 0 50px -30px rgba(15, 23, 42, 0.3);
+  }
+
+  .sidebar.is-open {
+    transform: translateX(0);
+  }
+
+  .sidebar::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    right: -40%;
+    bottom: 0;
+    left: 100%;
+  }
+
+  .sidebar__inner {
+    position: static;
+    top: auto;
+  }
+
+  .menu-button {
+    display: inline-flex;
+  }
+
+  .content {
+    padding: 1.5rem 1.75rem 3rem;
+  }
+}
+
+@media (max-width: 720px) {
+  .search {
+    display: none;
+  }
+
+  .topbar {
+    padding: 1rem 1.5rem;
+  }
+
+  .doc__section h1 {
+    font-size: 1.8rem;
+  }
+
+  .doc__section h2 {
+    font-size: 1.4rem;
+  }
+
+  .cards {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
## Summary
- redesign the landing page into a GitBook-inspired documentation layout with sample content and navigation anchors
- add a dedicated stylesheet that defines typography, colors, and responsive layout behavior for the theme
- introduce a lightweight script to handle the collapsible sidebar on smaller screens

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cf65a78518832681382f3bb4d93bfa