### PR TITLE
Ensure sidebar closes on desktop resize

### DIFF
--- a/script.js
+++ b/script.js
@@ -2,15 +2,30 @@ const menuButton = document.querySelector('.menu-button');
 const sidebar = document.querySelector('.sidebar');
 
 if (menuButton && sidebar) {
-  menuButton.addEventListener('click', () => {
-    const isOpen = sidebar.classList.toggle('is-open');
+  const setSidebarState = (isOpen) => {
+    sidebar.classList.toggle('is-open', isOpen);
+    document.body.classList.toggle('sidebar-open', isOpen);
     menuButton.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+  };
+
+  menuButton.addEventListener('click', () => {
+    const isOpen = sidebar.classList.contains('is-open');
+    setSidebarState(!isOpen);
   });
 
   sidebar.addEventListener('click', (event) => {
     if (event.target.matches('a')) {
-      sidebar.classList.remove('is-open');
-      menuButton.setAttribute('aria-expanded', 'false');
+      setSidebarState(false);
     }
   });
+
+  const desktopQuery = window.matchMedia('(min-width: 1080px)');
+  const handleDesktopChange = (event) => {
+    if (event.matches) {
+      setSidebarState(false);
+    }
+  };
+
+  handleDesktopChange(desktopQuery);
+  desktopQuery.addEventListener('change', handleDesktopChange);
 }


### PR DESCRIPTION
## Summary
- refactor the sidebar toggle to use a shared helper that syncs CSS classes and aria state
- add a desktop breakpoint media query listener that closes the sidebar when the layout switches back to desktop
- trigger the desktop handler once on load to clear any stale mobile-open state

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cf6d0806d483269872d5adcacaa7e5