### PR TITLE
Add GitBook-style content block examples

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,6 +64,7 @@
             <h2 class="sidebar__heading">References</h2>
             <ul class="sidebar__links">
               <li><a href="#components">Components</a></li>
+              <li><a href="#block-showcase">Block showcase</a></li>
               <li><a href="#faq">FAQ</a></li>
               <li><a href="#resources">Further resources</a></li>
             </ul>
@@ -194,6 +195,381 @@ npm run docs
                 <h3>Code blocks</h3>
                 <p>Share runnable examples or configuration snippets with syntax-friendly styling.</p>
               </article>
+            </div>
+          </section>
+
+          <section id="block-showcase" class="doc__section">
+            <h2>Block showcase</h2>
+            <p>
+              Use these pre-styled blocks to compose pages that feel consistent with GitBook's
+              typography and layout. Each example demonstrates how content appears inside this
+              template.
+            </p>
+
+            <div class="block-group" id="block-paragraphs">
+              <h3>Paragraphs</h3>
+              <p>
+                Documentation works best in short, purposeful paragraphs. You can guide the reader
+                through a concept, call out prerequisites, and follow up with next steps without
+                overwhelming them.
+              </p>
+              <p>
+                Combine paragraphs with other blocks like hints or lists to break up long walls of
+                text and keep your narrative engaging.
+              </p>
+            </div>
+
+            <div class="block-group" id="block-headings">
+              <h3>Headings</h3>
+              <div class="heading-showcase">
+                <p class="heading-showcase__item heading-showcase__item--h1">H1 — Page title</p>
+                <p class="heading-showcase__item heading-showcase__item--h2">H2 — Major topic</p>
+                <p class="heading-showcase__item heading-showcase__item--h3">H3 — Subsection</p>
+                <p class="heading-showcase__item heading-showcase__item--h4">H4 — Detail heading</p>
+              </div>
+            </div>
+
+            <div class="block-group" id="block-lists">
+              <h3>Lists</h3>
+              <div class="list-columns">
+                <div>
+                  <h4>Unordered list</h4>
+                  <ul>
+                    <li>Describe related tasks or concepts.</li>
+                    <li>Keep items short and scannable.</li>
+                    <li>Start each bullet with an action.</li>
+                  </ul>
+                </div>
+                <div>
+                  <h4>Ordered list</h4>
+                  <ol>
+                    <li>Draft your outline.</li>
+                    <li>Write content for every heading.</li>
+                    <li>Review the page for clarity.</li>
+                  </ol>
+                </div>
+              </div>
+            </div>
+
+            <div class="block-group" id="block-tasks">
+              <h3>Task lists</h3>
+              <ul class="task-list">
+                <li>
+                  <label>
+                    <input type="checkbox" checked disabled />
+                    Provision the documentation repository
+                  </label>
+                </li>
+                <li>
+                  <label>
+                    <input type="checkbox" disabled />
+                    Record walkthrough screenshots
+                  </label>
+                </li>
+                <li>
+                  <label>
+                    <input type="checkbox" disabled />
+                    Publish to the shared knowledge base
+                  </label>
+                </li>
+              </ul>
+            </div>
+
+            <div class="block-group" id="block-hints">
+              <h3>Hints</h3>
+              <div class="hint hint--info">
+                <p class="hint__title">Tip</p>
+                <p>Use hints to surface helpful context or shortcuts.</p>
+              </div>
+              <div class="hint hint--success">
+                <p class="hint__title">Success</p>
+                <p>Your configuration passed every validation check.</p>
+              </div>
+              <div class="hint hint--warning">
+                <p class="hint__title">Warning</p>
+                <p>Rotating API keys may temporarily invalidate running integrations.</p>
+              </div>
+            </div>
+
+            <div class="block-group" id="block-quotes">
+              <h3>Quotes</h3>
+              <blockquote class="quote">
+                “Clear, actionable documentation is the best onboarding teammate you will ever hire.”
+              </blockquote>
+            </div>
+
+            <div class="block-group" id="block-code">
+              <h3>Code blocks</h3>
+              <pre class="code-block"><code class="language-bash"># Install dependencies
+pnpm install
+
+# Start the docs site locally
+pnpm docs:dev
+</code></pre>
+            </div>
+
+            <div class="block-group" id="block-files">
+              <h3>Files</h3>
+              <div class="file-block">
+                <svg viewBox="0 0 24 24" aria-hidden="true" class="file-block__icon">
+                  <path
+                    fill="currentColor"
+                    d="M6 2a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8.828a2 2 0 00-.586-1.414l-4.828-4.828A2 2 0 0013.172 2H6zm6 2.414L17.586 10H13a1 1 0 01-1-1V4.414z"
+                  />
+                </svg>
+                <div>
+                  <p class="file-block__name">API-reference.pdf</p>
+                  <p class="file-block__meta">Updated 2 days ago · 1.4&nbsp;MB</p>
+                </div>
+                <a class="file-block__cta" href="#">Download</a>
+              </div>
+            </div>
+
+            <div class="block-group" id="block-images">
+              <h3>Images</h3>
+              <figure class="image-block">
+                <img
+                  src="https://images.unsplash.com/photo-1523475472560-d2df97ec485c?auto=format&fit=crop&w=800&q=80"
+                  alt="Organised sticky notes on a wall"
+                />
+                <figcaption>Use captions to describe what your readers should notice.</figcaption>
+              </figure>
+            </div>
+
+            <div class="block-group" id="block-embeds">
+              <h3>Embedded URLs</h3>
+              <a class="embed-card" href="https://www.gitbook.com/" target="_blank" rel="noreferrer">
+                <div class="embed-card__meta">
+                  <span class="embed-card__domain">gitbook.com</span>
+                  <span class="embed-card__action">Visit</span>
+                </div>
+                <p class="embed-card__title">Create beautiful documentation with GitBook</p>
+                <p class="embed-card__description">
+                  Explore publishing workflows, collaborative editing, and versioned changelogs.
+                </p>
+              </a>
+            </div>
+
+            <div class="block-group" id="block-table">
+              <h3>Tables</h3>
+              <table class="table table--compact">
+                <thead>
+                  <tr>
+                    <th>Tier</th>
+                    <th>Best for</th>
+                    <th>Monthly views</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>Starter</td>
+                    <td>Personal notes</td>
+                    <td>10K</td>
+                  </tr>
+                  <tr>
+                    <td>Team</td>
+                    <td>Internal knowledge bases</td>
+                    <td>250K</td>
+                  </tr>
+                  <tr>
+                    <td>Enterprise</td>
+                    <td>Compliance-heavy documentation</td>
+                    <td>Unlimited</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+
+            <div class="block-group" id="block-cards">
+              <h3>Cards</h3>
+              <div class="cards cards--compact">
+                <article class="card card--accent">
+                  <h4>Start writing</h4>
+                  <p>Draft your first page and invite collaborators.</p>
+                </article>
+                <article class="card card--accent">
+                  <h4>Connect integrations</h4>
+                  <p>Sync insights from Jira, Linear, and GitHub.</p>
+                </article>
+                <article class="card card--accent">
+                  <h4>Share updates</h4>
+                  <p>Publish changelogs to keep everyone aligned.</p>
+                </article>
+              </div>
+            </div>
+
+            <div class="block-group" id="block-tabs">
+              <h3>Tabs</h3>
+              <div class="tabs" data-tabs>
+                <div class="tab-list" role="tablist" aria-label="Plan comparison">
+                  <button type="button" role="tab" aria-selected="true" data-tab="plan-author">
+                    Authoring
+                  </button>
+                  <button type="button" role="tab" aria-selected="false" data-tab="plan-review">
+                    Review
+                  </button>
+                  <button type="button" role="tab" aria-selected="false" data-tab="plan-publish">
+                    Publish
+                  </button>
+                </div>
+                <div class="tab-panels">
+                  <div class="tab-panel" role="tabpanel" data-tab-panel="plan-author">
+                    <p>Draft ideas in pages, then organise them in collections.</p>
+                  </div>
+                  <div class="tab-panel" role="tabpanel" data-tab-panel="plan-review" hidden>
+                    <p>Request feedback with comments, suggestions, and approvals.</p>
+                  </div>
+                  <div class="tab-panel" role="tabpanel" data-tab-panel="plan-publish" hidden>
+                    <p>Publish to the web or keep content private to your workspace.</p>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="block-group" id="block-expandable">
+              <h3>Expandable</h3>
+              <details class="expandable">
+                <summary>How do I migrate an existing wiki?</summary>
+                <p>
+                  Export your current knowledge base as Markdown or HTML, then import it into GitBook
+                  to preserve structure, attachments, and authorship metadata.
+                </p>
+              </details>
+            </div>
+
+            <div class="block-group" id="block-stepper">
+              <h3>Stepper</h3>
+              <ol class="stepper">
+                <li class="stepper__step">
+                  <span class="stepper__badge">1</span>
+                  <div>
+                    <p class="stepper__title">Plan</p>
+                    <p class="stepper__body">Outline the journey your reader will take.</p>
+                  </div>
+                </li>
+                <li class="stepper__step">
+                  <span class="stepper__badge">2</span>
+                  <div>
+                    <p class="stepper__title">Build</p>
+                    <p class="stepper__body">Draft and refine each page in a collaborative space.</p>
+                  </div>
+                </li>
+                <li class="stepper__step">
+                  <span class="stepper__badge">3</span>
+                  <div>
+                    <p class="stepper__title">Launch</p>
+                    <p class="stepper__body">Publish the docs and announce the release internally.</p>
+                  </div>
+                </li>
+              </ol>
+            </div>
+
+            <div class="block-group" id="block-drawings">
+              <h3>Drawings</h3>
+              <figure class="drawing-block">
+                <svg viewBox="0 0 320 160" role="img" aria-labelledby="drawing-title">
+                  <title id="drawing-title">Simple architecture sketch</title>
+                  <rect x="16" y="24" width="96" height="64" rx="12" class="drawing-block__card" />
+                  <rect x="208" y="24" width="96" height="64" rx="12" class="drawing-block__card" />
+                  <rect x="112" y="96" width="96" height="48" rx="12" class="drawing-block__card" />
+                  <text x="64" y="60" text-anchor="middle">Client</text>
+                  <text x="256" y="60" text-anchor="middle">API</text>
+                  <text x="160" y="124" text-anchor="middle">Database</text>
+                  <path d="M112 56h96" class="drawing-block__arrow" />
+                  <path d="M160 88v8" class="drawing-block__arrow" />
+                </svg>
+                <figcaption>A lightweight SVG sketch communicates flows without leaving the page.</figcaption>
+              </figure>
+            </div>
+
+            <div class="block-group" id="block-math">
+              <h3>Math &amp; TeX</h3>
+              <p>
+                Inline math looks like <span class="math-inline">E = mc<sup>2</sup></span>, while block
+                equations stand alone for emphasis:
+              </p>
+              <div class="math-block">
+                <span>\[ \int_{a}^{b} f(x)\,dx = F(b) - F(a) \]</span>
+              </div>
+            </div>
+
+            <div class="block-group" id="block-pages">
+              <h3>Page links</h3>
+              <p>Surface related resources to help readers continue exploring:</p>
+              <ul class="page-links">
+                <li><a href="#quick-start">Quick start checklist</a></li>
+                <li><a href="#deployment">Deployment guide</a></li>
+                <li><a href="#faq">Frequently asked questions</a></li>
+              </ul>
+            </div>
+
+            <div class="block-group" id="block-columns">
+              <h3>Columns</h3>
+              <div class="columns">
+                <div class="column">
+                  <h4>Column A</h4>
+                  <p>Summarise a concept or provide a short checklist.</p>
+                </div>
+                <div class="column">
+                  <h4>Column B</h4>
+                  <p>Contrast the information or share a supporting example.</p>
+                </div>
+              </div>
+            </div>
+
+            <div class="block-group" id="block-conditional">
+              <h3>Conditional content</h3>
+              <div class="conditional" data-conditional>
+                <div class="conditional__controls" role="tablist" aria-label="Audience selector">
+                  <button type="button" role="tab" aria-selected="true" data-condition="developers">
+                    Developers
+                  </button>
+                  <button type="button" role="tab" aria-selected="false" data-condition="editors">
+                    Editors
+                  </button>
+                </div>
+                <div class="conditional__panels">
+                  <div class="conditional__panel" role="tabpanel" data-condition-panel="developers">
+                    <p>Install the CLI and authenticate using a personal access token.</p>
+                  </div>
+                  <div
+                    class="conditional__panel"
+                    role="tabpanel"
+                    data-condition-panel="editors"
+                    hidden
+                  >
+                    <p>Organise your space with collections and assign reviewers for every draft.</p>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="block-group" id="block-buttons">
+              <h3>Buttons</h3>
+              <div class="button-row">
+                <a class="button" href="#">Primary action</a>
+                <a class="button button--ghost" href="#">Secondary action</a>
+              </div>
+            </div>
+
+            <div class="block-group" id="block-icons">
+              <h3>Icons</h3>
+              <div class="icon-row">
+                <span class="icon-row__icon" aria-hidden="true">💡</span>
+                <span class="icon-row__icon" aria-hidden="true">🚀</span>
+                <span class="icon-row__icon" aria-hidden="true">🛠️</span>
+                <span class="icon-row__icon" aria-hidden="true">🔒</span>
+              </div>
+            </div>
+
+            <div class="block-group" id="block-expressions">
+              <h3>Expressions</h3>
+              <p>
+                Highlight dynamic values with templating-style expressions such as
+                <code class="expression">{{ deployment.environment }}</code> or
+                <code class="expression">{{ user.firstName }}</code> to show where automated data
+                will appear.
+              </p>
             </div>
           </section>
 

--- a/script.js
+++ b/script.js
@@ -29,3 +29,112 @@ if (menuButton && sidebar) {
   handleDesktopChange(desktopQuery);
   desktopQuery.addEventListener('change', handleDesktopChange);
 }
+
+const initialiseTabs = () => {
+  const tabGroups = document.querySelectorAll('[data-tabs]');
+  tabGroups.forEach((group) => {
+    const tabList = group.querySelector('.tab-list');
+    const tabButtons = tabList ? Array.from(tabList.querySelectorAll('[role="tab"]')) : [];
+    const panels = Array.from(group.querySelectorAll('[data-tab-panel]'));
+
+    const activateTab = (target) => {
+      const tabId = target.getAttribute('data-tab');
+      tabButtons.forEach((button) => {
+        const isActive = button === target;
+        button.setAttribute('aria-selected', isActive ? 'true' : 'false');
+        button.setAttribute('tabindex', isActive ? '0' : '-1');
+      });
+
+      panels.forEach((panel) => {
+        const matches = panel.getAttribute('data-tab-panel') === tabId;
+        panel.toggleAttribute('hidden', !matches);
+      });
+    };
+
+    tabButtons.forEach((button, index) => {
+      if (!button.hasAttribute('data-tab')) {
+        return;
+      }
+
+      if (!button.hasAttribute('tabindex')) {
+        button.setAttribute('tabindex', button.getAttribute('aria-selected') === 'true' ? '0' : '-1');
+      }
+
+      button.addEventListener('click', () => activateTab(button));
+
+      button.addEventListener('keydown', (event) => {
+        if (!['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event.key)) {
+          return;
+        }
+
+        event.preventDefault();
+        let newIndex = index;
+        if (event.key === 'ArrowRight') {
+          newIndex = (index + 1) % tabButtons.length;
+        } else if (event.key === 'ArrowLeft') {
+          newIndex = (index - 1 + tabButtons.length) % tabButtons.length;
+        } else if (event.key === 'Home') {
+          newIndex = 0;
+        } else if (event.key === 'End') {
+          newIndex = tabButtons.length - 1;
+        }
+
+        const nextTab = tabButtons[newIndex];
+        nextTab.focus();
+        activateTab(nextTab);
+      });
+    });
+  });
+};
+
+const initialiseConditionalBlocks = () => {
+  const conditionalBlocks = document.querySelectorAll('[data-conditional]');
+  conditionalBlocks.forEach((block) => {
+    const buttons = Array.from(block.querySelectorAll('[data-condition]'));
+    const panels = Array.from(block.querySelectorAll('[data-condition-panel]'));
+
+    const activateCondition = (value) => {
+      buttons.forEach((button) => {
+        const isActive = button.getAttribute('data-condition') === value;
+        button.setAttribute('aria-selected', isActive ? 'true' : 'false');
+        button.setAttribute('tabindex', isActive ? '0' : '-1');
+      });
+
+      panels.forEach((panel) => {
+        const matches = panel.getAttribute('data-condition-panel') === value;
+        panel.toggleAttribute('hidden', !matches);
+      });
+    };
+
+    buttons.forEach((button) => {
+      button.addEventListener('click', () => {
+        activateCondition(button.getAttribute('data-condition'));
+      });
+
+      if (!button.hasAttribute('tabindex')) {
+        button.setAttribute('tabindex', button.getAttribute('aria-selected') === 'true' ? '0' : '-1');
+      }
+
+      button.addEventListener('keydown', (event) => {
+        if (!['ArrowLeft', 'ArrowRight'].includes(event.key)) {
+          return;
+        }
+
+        event.preventDefault();
+        const currentIndex = buttons.indexOf(button);
+        if (currentIndex === -1) {
+          return;
+        }
+
+        const increment = event.key === 'ArrowRight' ? 1 : -1;
+        const nextIndex = (currentIndex + increment + buttons.length) % buttons.length;
+        const nextButton = buttons[nextIndex];
+        nextButton.focus();
+        activateCondition(nextButton.getAttribute('data-condition'));
+      });
+    });
+  });
+};
+
+initialiseTabs();
+initialiseConditionalBlocks();

--- a/styles.css
+++ b/styles.css
@@ -331,6 +331,497 @@ blockquote {
   margin-top: 0.75rem;
 }
 
+.block-group {
+  padding: 1.75rem 2rem;
+  background: var(--surface-color);
+  border: 1px solid var(--border-color);
+  border-radius: 1rem;
+  box-shadow: 0 18px 50px -35px var(--shadow-color);
+  margin-bottom: 2rem;
+}
+
+.block-group:last-child {
+  margin-bottom: 0;
+}
+
+.block-group h3 {
+  margin-top: 0;
+  margin-bottom: 1rem;
+}
+
+.heading-showcase {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.heading-showcase__item {
+  border: 1px dashed var(--border-color);
+  border-radius: 0.6rem;
+  padding: 0.75rem 1rem;
+  background: rgba(99, 102, 241, 0.04);
+  color: var(--primary-text);
+  font-weight: 600;
+}
+
+.heading-showcase__item--h1 {
+  font-size: 1.4rem;
+}
+
+.heading-showcase__item--h2 {
+  font-size: 1.2rem;
+}
+
+.heading-showcase__item--h3 {
+  font-size: 1.1rem;
+}
+
+.heading-showcase__item--h4 {
+  font-size: 1rem;
+}
+
+.list-columns {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.task-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.task-list label {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  background: rgba(99, 102, 241, 0.08);
+  border-radius: 0.7rem;
+  padding: 0.75rem 1rem;
+  font-weight: 500;
+  color: var(--primary-text);
+}
+
+.task-list input[type="checkbox"] {
+  accent-color: var(--primary-color);
+  width: 1rem;
+  height: 1rem;
+}
+
+.hint {
+  border-radius: 0.75rem;
+  padding: 1rem 1.25rem;
+  margin-bottom: 1rem;
+  border: 1px solid transparent;
+}
+
+.hint:last-child {
+  margin-bottom: 0;
+}
+
+.hint__title {
+  margin: 0 0 0.35rem;
+  font-weight: 600;
+}
+
+.hint--info {
+  background: rgba(99, 102, 241, 0.12);
+  border-color: rgba(99, 102, 241, 0.4);
+}
+
+.hint--success {
+  background: rgba(16, 185, 129, 0.12);
+  border-color: rgba(16, 185, 129, 0.4);
+}
+
+.hint--warning {
+  background: rgba(245, 158, 11, 0.12);
+  border-color: rgba(245, 158, 11, 0.45);
+}
+
+.quote {
+  font-size: 1.1rem;
+  font-style: italic;
+  background: rgba(15, 23, 42, 0.04);
+  border-left-color: rgba(99, 102, 241, 0.8);
+}
+
+.file-block {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 1rem;
+  align-items: center;
+  padding: 1rem 1.25rem;
+  border: 1px solid var(--border-color);
+  border-radius: 0.8rem;
+  background: rgba(15, 23, 42, 0.02);
+}
+
+.file-block__icon {
+  width: 36px;
+  height: 36px;
+  color: var(--primary-color);
+}
+
+.file-block__name {
+  margin: 0;
+  font-weight: 600;
+  color: var(--primary-text);
+}
+
+.file-block__meta {
+  margin: 0;
+  color: var(--muted-text);
+  font-size: 0.85rem;
+}
+
+.file-block__cta {
+  font-weight: 600;
+  color: var(--primary-color);
+  text-decoration: none;
+}
+
+.image-block {
+  margin: 0;
+  border-radius: 1rem;
+  overflow: hidden;
+  border: 1px solid var(--border-color);
+  box-shadow: 0 20px 45px -35px var(--shadow-color);
+}
+
+.image-block img {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.image-block figcaption {
+  margin: 0;
+  padding: 0.75rem 1rem;
+  background: rgba(15, 23, 42, 0.04);
+  font-size: 0.9rem;
+  color: var(--muted-text);
+}
+
+.embed-card {
+  display: block;
+  padding: 1.25rem 1.5rem;
+  border-radius: 1rem;
+  border: 1px solid var(--border-color);
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.08), rgba(99, 102, 241, 0.02));
+  text-decoration: none;
+  color: inherit;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.embed-card:hover,
+.embed-card:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 22px 60px -40px rgba(99, 102, 241, 0.6);
+  outline: none;
+}
+
+.embed-card__meta {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted-text);
+  margin-bottom: 0.5rem;
+}
+
+.embed-card__title {
+  margin: 0 0 0.35rem;
+  font-weight: 600;
+  color: var(--primary-text);
+}
+
+.embed-card__description {
+  margin: 0;
+}
+
+.table--compact {
+  margin-top: 1rem;
+}
+
+.cards--compact {
+  gap: 1rem;
+}
+
+.card--accent {
+  border: none;
+  background: linear-gradient(150deg, rgba(99, 102, 241, 0.12), rgba(99, 102, 241, 0.04));
+}
+
+.card--accent h4 {
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+}
+
+.tabs {
+  border: 1px solid var(--border-color);
+  border-radius: 1rem;
+  background: var(--surface-color);
+  overflow: hidden;
+}
+
+.tab-list {
+  display: flex;
+  background: rgba(99, 102, 241, 0.08);
+  padding: 0.5rem;
+  gap: 0.5rem;
+}
+
+.tab-list button {
+  flex: 1;
+  border: none;
+  background: transparent;
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  font-weight: 600;
+  color: var(--muted-text);
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.tab-list button[aria-selected="true"] {
+  background: var(--surface-color);
+  color: var(--primary-text);
+}
+
+.tab-panels {
+  padding: 1.25rem 1.5rem;
+}
+
+.expandable {
+  border: 1px solid var(--border-color);
+  border-radius: 0.8rem;
+  padding: 1rem 1.25rem;
+  background: var(--surface-color);
+  box-shadow: 0 14px 40px -30px var(--shadow-color);
+}
+
+.expandable summary {
+  cursor: pointer;
+  font-weight: 600;
+  color: var(--primary-text);
+}
+
+.expandable p {
+  margin-top: 0.75rem;
+}
+
+.stepper {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 1rem;
+}
+
+.stepper__step {
+  display: flex;
+  gap: 1rem;
+  align-items: flex-start;
+  background: rgba(15, 23, 42, 0.04);
+  border-radius: 0.9rem;
+  padding: 1rem 1.25rem;
+}
+
+.stepper__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: var(--primary-color);
+  color: #fff;
+  font-weight: 600;
+}
+
+.stepper__title {
+  margin: 0;
+  font-weight: 600;
+  color: var(--primary-text);
+}
+
+.stepper__body {
+  margin: 0.25rem 0 0;
+}
+
+.drawing-block {
+  margin: 0;
+  padding: 1.5rem;
+  border: 1px solid var(--border-color);
+  border-radius: 1rem;
+  background: var(--surface-color);
+  text-align: center;
+  box-shadow: 0 18px 60px -40px var(--shadow-color);
+}
+
+.drawing-block svg {
+  width: 100%;
+  max-width: 320px;
+  height: auto;
+  font-family: "Inter", sans-serif;
+  color: var(--primary-text);
+}
+
+.drawing-block__card {
+  fill: rgba(99, 102, 241, 0.1);
+  stroke: rgba(99, 102, 241, 0.4);
+  stroke-width: 2;
+}
+
+.drawing-block__arrow {
+  stroke: rgba(15, 23, 42, 0.5);
+  stroke-width: 3;
+  fill: none;
+}
+
+.drawing-block figcaption {
+  margin-top: 1rem;
+  color: var(--muted-text);
+}
+
+.math-inline {
+  font-family: "JetBrains Mono", monospace;
+  background: rgba(15, 23, 42, 0.05);
+  padding: 0.1rem 0.4rem;
+  border-radius: 0.35rem;
+}
+
+.math-block {
+  margin: 1rem 0 0;
+  padding: 1.25rem;
+  text-align: center;
+  background: rgba(99, 102, 241, 0.08);
+  border-radius: 0.9rem;
+  font-family: "JetBrains Mono", monospace;
+}
+
+.page-links {
+  margin: 0;
+  padding-left: 1.2rem;
+}
+
+.columns {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.column {
+  padding: 1.25rem;
+  border: 1px solid var(--border-color);
+  border-radius: 0.9rem;
+  background: rgba(15, 23, 42, 0.03);
+}
+
+.conditional {
+  border: 1px solid var(--border-color);
+  border-radius: 1rem;
+  overflow: hidden;
+  background: var(--surface-color);
+}
+
+.conditional__controls {
+  display: flex;
+  gap: 0.5rem;
+  padding: 0.6rem;
+  background: rgba(99, 102, 241, 0.08);
+}
+
+.conditional__controls button {
+  flex: 1;
+  border: none;
+  background: transparent;
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  font-weight: 600;
+  color: var(--muted-text);
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.conditional__controls button[aria-selected="true"] {
+  background: var(--surface-color);
+  color: var(--primary-text);
+}
+
+.conditional__panels {
+  padding: 1.25rem 1.5rem;
+}
+
+.button-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  padding: 0.75rem 1.4rem;
+  border-radius: 999px;
+  background: var(--primary-color);
+  color: #fff;
+  text-decoration: none;
+  font-weight: 600;
+  box-shadow: 0 18px 40px -28px rgba(99, 102, 241, 0.8);
+}
+
+.button--ghost {
+  background: transparent;
+  color: var(--primary-color);
+  border: 1px solid var(--primary-color);
+  box-shadow: none;
+}
+
+.icon-row {
+  display: flex;
+  gap: 1rem;
+  font-size: 1.8rem;
+}
+
+.icon-row__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  height: 48px;
+  border-radius: 0.8rem;
+  background: rgba(99, 102, 241, 0.1);
+}
+
+.expression {
+  background: rgba(15, 23, 42, 0.08);
+  border-radius: 0.5rem;
+  padding: 0.35rem 0.5rem;
+}
+
+@media (max-width: 900px) {
+  .block-group {
+    padding: 1.5rem;
+  }
+
+  .tab-list,
+  .conditional__controls {
+    flex-direction: column;
+  }
+
+  .tab-list button,
+  .conditional__controls button {
+    width: 100%;
+  }
+}
+
 .footer {
   margin-top: 4rem;
   padding: 2rem 0 0;


### PR DESCRIPTION
## Summary
- add a block showcase section illustrating GitBook-style content components such as paragraphs, lists, hints, embeds, cards, tabs, steppers, and more
- extend the stylesheet with visual treatments for the new block patterns while keeping the layout responsive
- enhance the JavaScript to support accessible tab and conditional content controls

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68cf738309bc8326acb69a87657a15f7